### PR TITLE
feat(tailwind): Add font-size aliases for text utilities

### DIFF
--- a/formats/tailwind/get-font-size.js
+++ b/formats/tailwind/get-font-size.js
@@ -9,14 +9,26 @@ module.exports.getFontSize = (dictionary) => {
   const secondaryFontSizes = getSecondaryFontSizesTokens(dictionary);
   const textFontSizes = getTextFontSizesTokens(dictionary);
 
-  return [...primaryFontSizes, ...secondaryFontSizes, ...textFontSizes].reduce(
-    (acc, token) => ({
-      ...acc,
-      [token.name.replace('typography-', '')]: [
-        token.value.fontSize,
-        { lineHeight: token.value.lineHeight, fontWeight: token.value.fontWeight },
-      ],
-    }),
-    {},
-  );
+  const tailwindAliases = {
+    'text-1': 'xl',
+    'text-2': 'lg',
+    'text-3': 'base',
+    'text-4': 'sm',
+  };
+
+  const fontSizes = [...primaryFontSizes, ...secondaryFontSizes, ...textFontSizes].reduce((acc, token) => {
+    const tokenKey = token.name.replace('typography-', '');
+
+    // Assign the original text-* key for backward compatibility
+    acc[tokenKey] = [token.value.fontSize, { lineHeight: token.value.lineHeight, fontWeight: token.value.fontWeight }];
+
+    // Add tailwind alias for text-* tokens
+    if (tailwindAliases[tokenKey]) {
+      acc[tailwindAliases[tokenKey]] = acc[tokenKey];
+    }
+
+    return acc;
+  }, {});
+
+  return fontSizes;
 };

--- a/formats/tailwind/get-font-size.js
+++ b/formats/tailwind/get-font-size.js
@@ -9,26 +9,14 @@ module.exports.getFontSize = (dictionary) => {
   const secondaryFontSizes = getSecondaryFontSizesTokens(dictionary);
   const textFontSizes = getTextFontSizesTokens(dictionary);
 
-  const tailwindAliases = {
-    'text-1': 'xl',
-    'text-2': 'lg',
-    'text-3': 'base',
-    'text-4': 'sm',
-  };
-
-  const fontSizes = [...primaryFontSizes, ...secondaryFontSizes, ...textFontSizes].reduce((acc, token) => {
-    const tokenKey = token.name.replace('typography-', '');
-
-    // Assign the original text-* key for backward compatibility
-    acc[tokenKey] = [token.value.fontSize, { lineHeight: token.value.lineHeight, fontWeight: token.value.fontWeight }];
-
-    // Add tailwind alias for text-* tokens
-    if (tailwindAliases[tokenKey]) {
-      acc[tailwindAliases[tokenKey]] = acc[tokenKey];
-    }
-
-    return acc;
-  }, {});
-
-  return fontSizes;
+  return [...primaryFontSizes, ...secondaryFontSizes, ...textFontSizes].reduce(
+    (acc, token) => ({
+      ...acc,
+      [token.name.replace('typography-', '').replace('text-', '')]: [
+        token.value.fontSize,
+        { lineHeight: token.value.lineHeight, fontWeight: token.value.fontWeight },
+      ],
+    }),
+    {},
+  );
 };

--- a/formats/tailwind/get-font-size.js
+++ b/formats/tailwind/get-font-size.js
@@ -9,14 +9,17 @@ module.exports.getFontSize = (dictionary) => {
   const secondaryFontSizes = getSecondaryFontSizesTokens(dictionary);
   const textFontSizes = getTextFontSizesTokens(dictionary);
 
-  return [...primaryFontSizes, ...secondaryFontSizes, ...textFontSizes].reduce(
-    (acc, token) => ({
-      ...acc,
-      [token.name.replace('typography-', '').replace('text-', '')]: [
-        token.value.fontSize,
-        { lineHeight: token.value.lineHeight, fontWeight: token.value.fontWeight },
-      ],
-    }),
-    {},
-  );
+  return [...primaryFontSizes, ...secondaryFontSizes, ...textFontSizes].reduce((acc, token) => {
+    let tokenKey = token.name.replace('typography-', '');
+
+    // Only remove the `text-` prefix for Tailwind built-ins
+    // Note: In the future, we should consider replacing `text-` prefixes for other tokens as well to avoid redundancy.
+    if (['text-sm', 'text-base', 'text-lg', 'text-xl'].some((utility) => token.name.includes(utility))) {
+      tokenKey = tokenKey.replace('text-', '');
+    }
+
+    acc[tokenKey] = [token.value.fontSize, { lineHeight: token.value.lineHeight, fontWeight: token.value.fontWeight }];
+
+    return acc;
+  }, {});
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axa-ch/design-tokens",
-  "version": "2.1.2",
+  "version": "2.3.0",
   "description": "AXA Design Tokens",
   "main": "./tokens.js",
   "module": "./tokens.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axa-ch/design-tokens",
-  "version": "2.2.0",
+  "version": "2.1.2",
   "description": "AXA Design Tokens",
   "main": "./tokens.js",
   "module": "./tokens.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axa-ch/design-tokens",
-  "version": "2.3.0",
+  "version": "2.2.0",
   "description": "AXA Design Tokens",
   "main": "./tokens.js",
   "module": "./tokens.mjs",

--- a/tests/tailwind.spec.ts
+++ b/tests/tailwind.spec.ts
@@ -50,4 +50,18 @@ describe('Tailwind Config specs', () => {
     expect(tailwindConfig.theme.fontFamily.primary).toHaveLength(3);
     expect(tailwindConfig.theme.fontFamily.secondary).toHaveLength(3);
   });
+
+  it('Font-size aliases are properly generated for text-* utilities', () => {
+    expect(tailwindConfig.theme.fontSize.sm).toEqual(tailwindConfig.theme.fontSize['text-4']);
+    expect(tailwindConfig.theme.fontSize.base).toEqual(tailwindConfig.theme.fontSize['text-3']);
+    expect(tailwindConfig.theme.fontSize.lg).toEqual(tailwindConfig.theme.fontSize['text-2']);
+    expect(tailwindConfig.theme.fontSize.xl).toEqual(tailwindConfig.theme.fontSize['text-1']);
+  });
+
+  it('Font-size text-<number> utilities are still available for backward compatibility', () => {
+    expect(tailwindConfig.theme.fontSize['text-1'][0]).toMatch(/rem$/);
+    expect(tailwindConfig.theme.fontSize['text-2'][0]).toMatch(/rem$/);
+    expect(tailwindConfig.theme.fontSize['text-3'][0]).toMatch(/rem$/);
+    expect(tailwindConfig.theme.fontSize['text-4'][0]).toMatch(/rem$/);
+  });
 });

--- a/tests/tailwind.spec.ts
+++ b/tests/tailwind.spec.ts
@@ -52,16 +52,16 @@ describe('Tailwind Config specs', () => {
   });
 
   it('Font-size aliases are properly generated for text-* utilities', () => {
-    expect(tailwindConfig.theme.fontSize.sm).toEqual(tailwindConfig.theme.fontSize['4']);
-    expect(tailwindConfig.theme.fontSize.base).toEqual(tailwindConfig.theme.fontSize['3']);
-    expect(tailwindConfig.theme.fontSize.lg).toEqual(tailwindConfig.theme.fontSize['2']);
-    expect(tailwindConfig.theme.fontSize.xl).toEqual(tailwindConfig.theme.fontSize['1']);
+    expect(tailwindConfig.theme.fontSize.sm).toEqual(tailwindConfig.theme.fontSize['text-4']);
+    expect(tailwindConfig.theme.fontSize.base).toEqual(tailwindConfig.theme.fontSize['text-3']);
+    expect(tailwindConfig.theme.fontSize.lg).toEqual(tailwindConfig.theme.fontSize['text-2']);
+    expect(tailwindConfig.theme.fontSize.xl).toEqual(tailwindConfig.theme.fontSize['text-1']);
   });
 
   it('Font-size <number> utilities are still available for backward compatibility', () => {
-    expect(tailwindConfig.theme.fontSize['1'][0]).toMatch(/rem$/);
-    expect(tailwindConfig.theme.fontSize['2'][0]).toMatch(/rem$/);
-    expect(tailwindConfig.theme.fontSize['3'][0]).toMatch(/rem$/);
-    expect(tailwindConfig.theme.fontSize['4'][0]).toMatch(/rem$/);
+    expect(tailwindConfig.theme.fontSize['text-1'][0]).toMatch(/rem$/);
+    expect(tailwindConfig.theme.fontSize['text-2'][0]).toMatch(/rem$/);
+    expect(tailwindConfig.theme.fontSize['text-3'][0]).toMatch(/rem$/);
+    expect(tailwindConfig.theme.fontSize['text-4'][0]).toMatch(/rem$/);
   });
 });

--- a/tests/tailwind.spec.ts
+++ b/tests/tailwind.spec.ts
@@ -52,16 +52,16 @@ describe('Tailwind Config specs', () => {
   });
 
   it('Font-size aliases are properly generated for text-* utilities', () => {
-    expect(tailwindConfig.theme.fontSize.sm).toEqual(tailwindConfig.theme.fontSize['text-4']);
-    expect(tailwindConfig.theme.fontSize.base).toEqual(tailwindConfig.theme.fontSize['text-3']);
-    expect(tailwindConfig.theme.fontSize.lg).toEqual(tailwindConfig.theme.fontSize['text-2']);
-    expect(tailwindConfig.theme.fontSize.xl).toEqual(tailwindConfig.theme.fontSize['text-1']);
+    expect(tailwindConfig.theme.fontSize.sm).toEqual(tailwindConfig.theme.fontSize['4']);
+    expect(tailwindConfig.theme.fontSize.base).toEqual(tailwindConfig.theme.fontSize['3']);
+    expect(tailwindConfig.theme.fontSize.lg).toEqual(tailwindConfig.theme.fontSize['2']);
+    expect(tailwindConfig.theme.fontSize.xl).toEqual(tailwindConfig.theme.fontSize['1']);
   });
 
-  it('Font-size text-<number> utilities are still available for backward compatibility', () => {
-    expect(tailwindConfig.theme.fontSize['text-1'][0]).toMatch(/rem$/);
-    expect(tailwindConfig.theme.fontSize['text-2'][0]).toMatch(/rem$/);
-    expect(tailwindConfig.theme.fontSize['text-3'][0]).toMatch(/rem$/);
-    expect(tailwindConfig.theme.fontSize['text-4'][0]).toMatch(/rem$/);
+  it('Font-size <number> utilities are still available for backward compatibility', () => {
+    expect(tailwindConfig.theme.fontSize['1'][0]).toMatch(/rem$/);
+    expect(tailwindConfig.theme.fontSize['2'][0]).toMatch(/rem$/);
+    expect(tailwindConfig.theme.fontSize['3'][0]).toMatch(/rem$/);
+    expect(tailwindConfig.theme.fontSize['4'][0]).toMatch(/rem$/);
   });
 });

--- a/tokens.json
+++ b/tokens.json
@@ -32,6 +32,42 @@
   "breakpoints-base-xs": {
     "value": 0
   },
+  "typography-text-xl": {
+    "value": {
+      "fontFamily": "Source Sans Pro, Arial, sans-serif",
+      "fontWeight": 400,
+      "fontSize": "20px",
+      "lineHeight": 1.5
+    },
+    "type": "typography"
+  },
+  "typography-text-lg": {
+    "value": {
+      "fontFamily": "Source Sans Pro, Arial, sans-serif",
+      "fontWeight": 400,
+      "fontSize": "18px",
+      "lineHeight": 1.5
+    },
+    "type": "typography"
+  },
+  "typography-text-sm": {
+    "value": {
+      "fontFamily": "Source Sans Pro, Arial, sans-serif",
+      "fontWeight": 400,
+      "fontSize": "14px",
+      "lineHeight": 1.214
+    },
+    "type": "typography"
+  },
+  "typography-text-base": {
+    "value": {
+      "fontFamily": "Source Sans Pro, Arial, sans-serif",
+      "fontWeight": 400,
+      "fontSize": "16px",
+      "lineHeight": 1.5
+    },
+    "type": "typography"
+  },
   "typography-text-4": {
     "value": {
       "fontFamily": "Source Sans Pro, Arial, sans-serif",

--- a/tokens/globals/typography/text.json
+++ b/tokens/globals/typography/text.json
@@ -36,6 +36,42 @@
           "lineHeight": "{typography.line-height.8}"
         },
         "type": "typography"
+      },
+      "base": {
+        "value": {
+          "fontFamily": "{typography.font-family.primary}, {typography.font-family.primary-fallback-1}, {typography.font-family.primary-fallback-2}",
+          "fontWeight": 400,
+          "fontSize": "{typography.font-size.2}",
+          "lineHeight": "{typography.line-height.10}"
+        },
+        "type": "typography"
+      },
+      "sm": {
+        "value": {
+          "fontFamily": "{typography.font-family.primary}, {typography.font-family.primary-fallback-1}, {typography.font-family.primary-fallback-2}",
+          "fontWeight": 400,
+          "fontSize": "{typography.font-size.1}",
+          "lineHeight": "{typography.line-height.8}"
+        },
+        "type": "typography"
+      },
+      "lg": {
+        "value": {
+          "fontFamily": "{typography.font-family.primary}, {typography.font-family.primary-fallback-1}, {typography.font-family.primary-fallback-2}",
+          "fontWeight": 400,
+          "fontSize": "{typography.font-size.3}",
+          "lineHeight": "{typography.line-height.10}"
+        },
+        "type": "typography"
+      },
+      "xl": {
+        "value": {
+          "fontFamily": "{typography.font-family.primary}, {typography.font-family.primary-fallback-1}, {typography.font-family.primary-fallback-2}",
+          "fontWeight": 400,
+          "fontSize": "{typography.font-size.4}",
+          "lineHeight": "{typography.line-height.10}"
+        },
+        "type": "typography"
       }
     }
   }


### PR DESCRIPTION
This PR introduces new font-size aliases (`sm`, `base`, `lg`, `xl`) to the existing `text-<number>` utilities to the Tailwind configuration. The current config generates classes like `text-text-1`, which can seem unintuitive and redundant. Additionally, the existing setup prevents the use of default Tailwind utilities such as `text-sm` and `text-base`.

### Prerequisites
- [x] Use a meaningful title for the pull request
- [x] Test the changes you've made by adding or editing tests

### Content
- Added font-size aliases for text utilities in the Tailwind configuration
- Preserved backward compatibility with existing text utilities

### Tests
- Added tests to ensure that the new font-size aliases are correctly generated and mapped to their respective `text-<number>` parts
- Verified backward compatibility by testing the existence of `text-<number>` utilities